### PR TITLE
fix: declare the logical plan schema in DoGet to match GetFlightInfo

### DIFF
--- a/datafusion-flight-sql-server/src/service.rs
+++ b/datafusion-flight-sql-server/src/service.rs
@@ -37,7 +37,6 @@ use datafusion::arrow::{
 };
 use datafusion::{
     common::{arrow::datatypes::Schema, ParamValues},
-    dataframe::DataFrame,
     datasource::TableType,
     error::{DataFusionError, Result as DataFusionResult},
     execution::context::{SQLOptions, SessionContext, SessionState},
@@ -174,11 +173,6 @@ impl FlightSqlSessionContext {
         Ok(plan)
     }
 
-    async fn execute_sql(&self, sql: &str) -> DataFusionResult<SendableRecordBatchStream> {
-        let plan = self.sql_to_logical_plan(sql).await?;
-        self.execute_logical_plan(plan).await
-    }
-
     async fn execute_logical_plan(
         &self,
         plan: LogicalPlan,
@@ -216,76 +210,33 @@ impl ArrowFlightSqlService for FlightSqlService {
         let ticket = CommandTicket::try_decode(request.into_inner().ticket)
             .map_err(flight_error_to_status)?;
 
-        match ticket.command {
-            sql::Command::CommandStatementQuery(CommandStatementQuery { query, .. }) => {
-                // print!("Query: {query}\n");
-
-                // Declare the logical-plan schema (the same schema that
-                // GetFlightInfo advertises) rather than the physical stream
-                // schema. The two can differ in field nullability (e.g. for
-                // aggregates), and strict clients such as the ADBC Flight SQL
-                // driver reject a DoGet stream whose schema does not match
-                // the advertised FlightInfo schema exactly.
-                let plan = ctx
-                    .sql_to_logical_plan(&query)
-                    .await
-                    .map_err(df_error_to_status)?;
-                let arrow_schema = get_schema_for_plan(&plan, self.config.schema_with_metadata);
-                let stream = ctx
-                    .execute_logical_plan(plan)
-                    .await
-                    .map_err(df_error_to_status)?;
-                let arrow_stream = stream.map(|i| {
-                    let batch = i.map_err(|e| FlightError::ExternalError(e.into()))?;
-                    Ok(batch)
-                });
-
-                let flight_data_stream = FlightDataEncoderBuilder::new()
-                    .with_schema(arrow_schema)
-                    .build(arrow_stream)
-                    .map_err(flight_error_to_status)
-                    .boxed();
-
-                Ok(Response::new(flight_data_stream))
-            }
+        // All query arms declare the logical plan schema (the very same schema
+        // that the matching `get_flight_info_*` advertises) rather than the
+        // physical stream schema. The two can differ in field nullability
+        // (e.g. aggregates over statistics-backed sources), and strict clients
+        // such as the ADBC Flight SQL driver reject a DoGet stream whose schema
+        // does not match the advertised FlightInfo schema exactly.
+        let plan = match ticket.command {
+            sql::Command::CommandStatementQuery(CommandStatementQuery { query, .. }) => ctx
+                .sql_to_logical_plan(&query)
+                .await
+                .map_err(df_error_to_status)?,
             sql::Command::CommandPreparedStatementQuery(CommandPreparedStatementQuery {
                 prepared_statement_handle,
             }) => {
                 let handle = QueryHandle::try_decode(prepared_statement_handle)?;
 
-                let mut plan = ctx
+                let plan = ctx
                     .sql_to_logical_plan(handle.query())
                     .await
                     .map_err(df_error_to_status)?;
 
-                if let Some(param_values) =
-                    decode_param_values(handle.parameters()).map_err(arrow_error_to_status)?
-                {
-                    plan = plan
+                match decode_param_values(handle.parameters()).map_err(arrow_error_to_status)? {
+                    Some(param_values) => plan
                         .with_param_values(param_values)
-                        .map_err(df_error_to_status)?;
+                        .map_err(df_error_to_status)?,
+                    None => plan,
                 }
-
-                // Same schema consistency requirement as for
-                // CommandStatementQuery above.
-                let arrow_schema =
-                    get_schema_for_plan(&plan, self.config.schema_with_metadata);
-                let stream = ctx
-                    .execute_logical_plan(plan)
-                    .await
-                    .map_err(df_error_to_status)?;
-                let arrow_stream = stream.map(|i| {
-                    let batch = i.map_err(|e| FlightError::ExternalError(e.into()))?;
-                    Ok(batch)
-                });
-
-                let flight_data_stream = FlightDataEncoderBuilder::new()
-                    .with_schema(arrow_schema)
-                    .build(arrow_stream)
-                    .map_err(flight_error_to_status)
-                    .boxed();
-
-                Ok(Response::new(flight_data_stream))
             }
             sql::Command::CommandStatementSubstraitPlan(CommandStatementSubstraitPlan {
                 plan,
@@ -297,28 +248,7 @@ impl ArrowFlightSqlService for FlightSqlService {
                     ))?
                     .plan;
 
-                let plan = parse_substrait_bytes(&ctx, substrait_bytes).await?;
-
-                // Same schema consistency requirement as for
-                // CommandStatementQuery above.
-                let arrow_schema =
-                    get_schema_for_plan(&plan, self.config.schema_with_metadata);
-                let state = ctx.inner.state();
-                let df = DataFrame::new(state, plan);
-
-                let stream = df.execute_stream().await.map_err(df_error_to_status)?;
-                let arrow_stream = stream.map(|i| {
-                    let batch = i.map_err(|e| FlightError::ExternalError(e.into()))?;
-                    Ok(batch)
-                });
-
-                let flight_data_stream = FlightDataEncoderBuilder::new()
-                    .with_schema(arrow_schema)
-                    .build(arrow_stream)
-                    .map_err(flight_error_to_status)
-                    .boxed();
-
-                Ok(Response::new(flight_data_stream))
+                parse_substrait_bytes(&ctx, substrait_bytes).await?
             }
             _ => {
                 return Err(Status::internal(format!(
@@ -326,7 +256,23 @@ impl ArrowFlightSqlService for FlightSqlService {
                     ticket.command
                 )));
             }
-        }
+        };
+
+        let arrow_schema = get_schema_for_plan(&plan, self.config.schema_with_metadata);
+        let stream = ctx
+            .execute_logical_plan(plan)
+            .await
+            .map_err(df_error_to_status)?;
+
+        let arrow_stream = stream.map_err(|e| FlightError::ExternalError(e.into()));
+
+        let flight_data_stream = FlightDataEncoderBuilder::new()
+            .with_schema(arrow_schema)
+            .build(arrow_stream)
+            .map_err(flight_error_to_status)
+            .boxed();
+
+        Ok(Response::new(flight_data_stream))
     }
 
     async fn get_flight_info_statement(

--- a/datafusion-flight-sql-server/src/service.rs
+++ b/datafusion-flight-sql-server/src/service.rs
@@ -220,8 +220,21 @@ impl ArrowFlightSqlService for FlightSqlService {
             sql::Command::CommandStatementQuery(CommandStatementQuery { query, .. }) => {
                 // print!("Query: {query}\n");
 
-                let stream = ctx.execute_sql(&query).await.map_err(df_error_to_status)?;
-                let arrow_schema = stream.schema();
+                // Declare the logical-plan schema (the same schema that
+                // GetFlightInfo advertises) rather than the physical stream
+                // schema. The two can differ in field nullability (e.g. for
+                // aggregates), and strict clients such as the ADBC Flight SQL
+                // driver reject a DoGet stream whose schema does not match
+                // the advertised FlightInfo schema exactly.
+                let plan = ctx
+                    .sql_to_logical_plan(&query)
+                    .await
+                    .map_err(df_error_to_status)?;
+                let arrow_schema = get_schema_for_plan(&plan, self.config.schema_with_metadata);
+                let stream = ctx
+                    .execute_logical_plan(plan)
+                    .await
+                    .map_err(df_error_to_status)?;
                 let arrow_stream = stream.map(|i| {
                     let batch = i.map_err(|e| FlightError::ExternalError(e.into()))?;
                     Ok(batch)
@@ -253,11 +266,14 @@ impl ArrowFlightSqlService for FlightSqlService {
                         .map_err(df_error_to_status)?;
                 }
 
+                // Same schema consistency requirement as for
+                // CommandStatementQuery above.
+                let arrow_schema =
+                    get_schema_for_plan(&plan, self.config.schema_with_metadata);
                 let stream = ctx
                     .execute_logical_plan(plan)
                     .await
                     .map_err(df_error_to_status)?;
-                let arrow_schema = stream.schema();
                 let arrow_stream = stream.map(|i| {
                     let batch = i.map_err(|e| FlightError::ExternalError(e.into()))?;
                     Ok(batch)
@@ -283,11 +299,14 @@ impl ArrowFlightSqlService for FlightSqlService {
 
                 let plan = parse_substrait_bytes(&ctx, substrait_bytes).await?;
 
+                // Same schema consistency requirement as for
+                // CommandStatementQuery above.
+                let arrow_schema =
+                    get_schema_for_plan(&plan, self.config.schema_with_metadata);
                 let state = ctx.inner.state();
                 let df = DataFrame::new(state, plan);
 
                 let stream = df.execute_stream().await.map_err(df_error_to_status)?;
-                let arrow_schema = stream.schema();
                 let arrow_stream = stream.map(|i| {
                     let batch = i.map_err(|e| FlightError::ExternalError(e.into()))?;
                     Ok(batch)

--- a/datafusion-flight-sql-server/tests/integration_test.rs
+++ b/datafusion-flight-sql-server/tests/integration_test.rs
@@ -326,3 +326,92 @@ async fn test_query_with_join() {
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(total_rows, 4, "Should have 4 rows from join");
 }
+
+#[tokio::test]
+async fn test_do_get_schema_matches_advertised_flight_info_schema() {
+    use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::prelude::ParquetReadOptions;
+
+    // Aggregates over statistics-backed sources (e.g. Parquet) are a case
+    // where the logical plan schema (advertised in FlightInfo) and the
+    // physical stream schema disagree on field nullability: the optimizer
+    // rewrites MIN() into a non-nullable literal taken from the file
+    // statistics, while the logical schema keeps MIN() nullable. Strict
+    // clients (e.g. the ADBC Flight SQL driver) reject the DoGet stream
+    // if its schema does not exactly match the one advertised in
+    // FlightInfo.
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "amount",
+        DataType::Int32,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![50, 75, 100, 25]))],
+    )
+    .unwrap();
+    let path = std::env::temp_dir().join(format!(
+        "flight_sql_schema_test_{}.parquet",
+        std::process::id()
+    ));
+    let file = std::fs::File::create(&path).expect("create parquet file");
+    let mut writer = ArrowWriter::try_new(file, schema, None).expect("create writer");
+    writer.write(&batch).expect("write batch");
+    writer.close().expect("close writer");
+
+    let ctx = SessionContext::new();
+    ctx.register_parquet(
+        "orders_pq",
+        path.to_str().expect("utf-8 path"),
+        ParquetReadOptions::default(),
+    )
+    .await
+    .expect("register parquet");
+
+    let addr = "0.0.0.0:50069";
+    start_test_server(addr.to_string(), ctx.state()).await;
+
+    let mut client = create_test_client(&format!("http://{}", addr)).await;
+
+    let flight_info = client
+        .execute(
+            "SELECT MIN(amount) AS lo, COUNT(*) AS n FROM orders_pq".to_string(),
+            None,
+        )
+        .await
+        .expect("Query should succeed");
+
+    let advertised = flight_info
+        .clone()
+        .try_decode_schema()
+        .expect("FlightInfo should carry a schema");
+
+    let ticket = flight_info
+        .endpoint
+        .first()
+        .expect("Should have endpoint")
+        .ticket
+        .clone()
+        .expect("Should have ticket");
+
+    let mut stream = client.do_get(ticket).await.expect("do_get should succeed");
+    while stream
+        .try_next()
+        .await
+        .expect("Stream should work")
+        .is_some()
+    {}
+
+    let actual = stream
+        .schema()
+        .expect("DoGet stream should declare a schema")
+        .clone();
+
+    std::fs::remove_file(&path).ok();
+
+    assert_eq!(
+        advertised,
+        *actual,
+        "DoGet stream schema must match the schema advertised in FlightInfo"
+    );
+}

--- a/datafusion-flight-sql-server/tests/integration_test.rs
+++ b/datafusion-flight-sql-server/tests/integration_test.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use arrow_flight::sql::client::FlightSqlServiceClient;
+use arrow_flight::{sql::client::FlightSqlServiceClient, FlightInfo};
 use datafusion::arrow::{
     array::{Int32Array, RecordBatch, StringArray},
     datatypes::{DataType, Field, Schema},
@@ -8,6 +8,8 @@ use datafusion::arrow::{
 use datafusion::{
     datasource::MemTable,
     execution::context::{SessionContext, SessionState},
+    parquet::arrow::ArrowWriter,
+    prelude::ParquetReadOptions,
 };
 use datafusion_flight_sql_server::service::FlightSqlService;
 use futures::TryStreamExt;
@@ -327,19 +329,22 @@ async fn test_query_with_join() {
     assert_eq!(total_rows, 4, "Should have 4 rows from join");
 }
 
-#[tokio::test]
-async fn test_do_get_schema_matches_advertised_flight_info_schema() {
-    use datafusion::parquet::arrow::ArrowWriter;
-    use datafusion::prelude::ParquetReadOptions;
+/// The query used by the schema-consistency tests below.
+///
+/// Aggregates over statistics-backed sources (e.g. Parquet) are a case where
+/// the logical plan schema (advertised in `FlightInfo`) and the physical stream
+/// schema disagree on field nullability: the `AggregateStatistics` optimizer
+/// rewrites `MIN()` into a non-nullable literal taken from the file statistics,
+/// while the logical schema keeps `MIN()` nullable. Strict clients (e.g. the
+/// ADBC Flight SQL driver) reject a `DoGet` stream whose schema does not
+/// exactly match the one advertised in `FlightInfo`.
+const AGGREGATE_OVER_PARQUET: &str = "SELECT MIN(amount) AS lo, COUNT(*) AS n FROM orders_pq";
 
-    // Aggregates over statistics-backed sources (e.g. Parquet) are a case
-    // where the logical plan schema (advertised in FlightInfo) and the
-    // physical stream schema disagree on field nullability: the optimizer
-    // rewrites MIN() into a non-nullable literal taken from the file
-    // statistics, while the logical schema keeps MIN() nullable. Strict
-    // clients (e.g. the ADBC Flight SQL driver) reject the DoGet stream
-    // if its schema does not exactly match the one advertised in
-    // FlightInfo.
+/// Registers a single-column Parquet table named `orders_pq`.
+///
+/// The file lives in the per-test-binary temp directory that Cargo manages, so
+/// a panicking test cannot leave stray files behind in the system temp dir.
+async fn create_parquet_session(file_name: &str) -> SessionState {
     let schema = Arc::new(Schema::new(vec![Field::new(
         "amount",
         DataType::Int32,
@@ -350,10 +355,8 @@ async fn test_do_get_schema_matches_advertised_flight_info_schema() {
         vec![Arc::new(Int32Array::from(vec![50, 75, 100, 25]))],
     )
     .unwrap();
-    let path = std::env::temp_dir().join(format!(
-        "flight_sql_schema_test_{}.parquet",
-        std::process::id()
-    ));
+
+    let path = std::path::Path::new(env!("CARGO_TARGET_TMPDIR")).join(file_name);
     let file = std::fs::File::create(&path).expect("create parquet file");
     let mut writer = ArrowWriter::try_new(file, schema, None).expect("create writer");
     writer.write(&batch).expect("write batch");
@@ -368,24 +371,15 @@ async fn test_do_get_schema_matches_advertised_flight_info_schema() {
     .await
     .expect("register parquet");
 
-    let addr = "0.0.0.0:50069";
-    start_test_server(addr.to_string(), ctx.state()).await;
+    ctx.state()
+}
 
-    let mut client = create_test_client(&format!("http://{}", addr)).await;
-
-    let flight_info = client
-        .execute(
-            "SELECT MIN(amount) AS lo, COUNT(*) AS n FROM orders_pq".to_string(),
-            None,
-        )
-        .await
-        .expect("Query should succeed");
-
-    let advertised = flight_info
-        .clone()
-        .try_decode_schema()
-        .expect("FlightInfo should carry a schema");
-
+/// Fetches the endpoint's `DoGet` stream, drains it, and returns the schema the
+/// stream declared on the wire.
+async fn do_get_stream_schema(
+    client: &mut FlightSqlServiceClient<Channel>,
+    flight_info: &FlightInfo,
+) -> Schema {
     let ticket = flight_info
         .endpoint
         .first()
@@ -395,6 +389,8 @@ async fn test_do_get_schema_matches_advertised_flight_info_schema() {
         .expect("Should have ticket");
 
     let mut stream = client.do_get(ticket).await.expect("do_get should succeed");
+    // Drain the stream: decoding the batches also validates them against the
+    // declared schema, so a schema that does not fit the data fails here.
     while stream
         .try_next()
         .await
@@ -402,16 +398,75 @@ async fn test_do_get_schema_matches_advertised_flight_info_schema() {
         .is_some()
     {}
 
-    let actual = stream
+    stream
         .schema()
         .expect("DoGet stream should declare a schema")
-        .clone();
+        .as_ref()
+        .clone()
+}
 
-    std::fs::remove_file(&path).ok();
+/// Asserts that `MIN(amount)` is still advertised as nullable, i.e. that the
+/// query really does exercise the logical/physical schema divergence and the
+/// test has not silently become vacuous.
+fn assert_exercises_nullability_divergence(advertised: &Schema) {
+    let lo = advertised.field_with_name("lo").expect("lo field");
+    assert!(
+        lo.is_nullable(),
+        "MIN() must be advertised as nullable for this test to be meaningful, got {lo:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_do_get_schema_matches_advertised_flight_info_schema() {
+    let addr = "0.0.0.0:50069";
+    let state = create_parquet_session("statement_query.parquet").await;
+    start_test_server(addr.to_string(), state).await;
+
+    let mut client = create_test_client(&format!("http://{}", addr)).await;
+
+    let flight_info = client
+        .execute(AGGREGATE_OVER_PARQUET.to_string(), None)
+        .await
+        .expect("Query should succeed");
+
+    let advertised = flight_info
+        .clone()
+        .try_decode_schema()
+        .expect("FlightInfo should carry a schema");
+    assert_exercises_nullability_divergence(&advertised);
+
+    let actual = do_get_stream_schema(&mut client, &flight_info).await;
 
     assert_eq!(
-        advertised,
-        *actual,
+        advertised, actual,
+        "DoGet stream schema must match the schema advertised in FlightInfo"
+    );
+}
+
+#[tokio::test]
+async fn test_prepared_do_get_schema_matches_advertised_flight_info_schema() {
+    let addr = "0.0.0.0:50070";
+    let state = create_parquet_session("prepared_statement_query.parquet").await;
+    start_test_server(addr.to_string(), state).await;
+
+    let mut client = create_test_client(&format!("http://{}", addr)).await;
+
+    let mut prepared = client
+        .prepare(AGGREGATE_OVER_PARQUET.to_string(), None)
+        .await
+        .expect("Prepare should succeed");
+
+    let flight_info = prepared.execute().await.expect("Query should succeed");
+    let advertised = flight_info
+        .clone()
+        .try_decode_schema()
+        .expect("FlightInfo should carry a schema");
+    assert_exercises_nullability_divergence(&advertised);
+
+    let actual = do_get_stream_schema(&mut client, &flight_info).await;
+
+    assert_eq!(
+        advertised, actual,
         "DoGet stream schema must match the schema advertised in FlightInfo"
     );
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes [#51](https://github.com/datafusion-contrib/datafusion-flight-sql-server/issues/51).

## What changes are included in this PR?

`do_get_fallback` currently declares the **physical execution stream** schema (`stream.schema()`) on the wire, while `get_flight_info_*` advertises the **logical plan** schema (`get_schema_for_plan(...)`).

The two can disagree on field nullability — reproduced with aggregates over statistics-backed sources such as Parquet, where the `AggregateStatistics` optimizer rewrites `MIN()`/`MAX()` into non-nullable literals taken from file statistics while the advertised logical schema keeps them nullable.

Strict clients that validate the `DoGet` stream against the advertised `FlightInfo` schema — notably the Go ADBC Flight SQL driver and therefore Python's `adbc-driver-flightsql` — reject such results:

```
[FlightSQL] endpoint 0 returned inconsistent schema:
expected schema: ... lo: type=int64, nullable
but got schema:  ... lo: type=int64
```

This PR makes all three arms of `do_get_fallback` (`CommandStatementQuery`, `CommandPreparedStatementQuery`,
`CommandStatementSubstraitPlan`) derive the declared schema from the logical plan via the same `get_schema_for_plan(...)` call that `GetFlightInfo` uses, so the advertised and streamed schemas always match. 

The encoded batches themselves are unchanged; declaring the (more permissive) logical schema is always valid for the data, while the previous behavior was the direction that breaks readers.

For `CommandStatementQuery` this replaces `ctx.execute_sql(&query)` with the equivalent `sql_to_logical_plan` + `execute_logical_plan` pair so the plan is available for schema derivation; the other two arms already had the plan in hand.

## Are these changes tested?

Yes — a new integration test (`test_do_get_schema_matches_advertised_flight_info_schema`) writes a small Parquet file, executes an aggregate query against it, decodes the schema from `FlightInfo`, consumes the `DoGet` stream, and asserts the stream's declared schema equals the advertised one. The test fails against `main`:

```
assertion `left == right` failed: DoGet stream schema must match the schema advertised in FlightInfo
  left: Schema { fields: [Field { name: "lo", data_type: Int32, nullable: true }, ...] }
 right: Schema { fields: [Field { name: "lo", data_type: Int32 }, ...] }
```

and passes with this change. All existing tests pass unchanged.

## Are there any user-facing changes?

Result schemas for queries whose logical/physical schemas differ in nullability are now reported with the logical (nullable) variant consistently in both `GetFlightInfo` and `DoGet`. Clients that previously failed with "inconsistent schema" errors (e.g. all ADBC Flight SQL consumers) now work.
